### PR TITLE
Fixed the 'props.xys' is undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prettier": "^1.16.4",
     "react": "^16.8.0",
     "react-scripts": "^2.1.3",
-    "react-spring": "^8.0.14",
+    "react-spring": "^8.0.27",
     "rollup": "^1.1.2",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^9.2.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,56 +3,72 @@ import { useState, useEffect } from "react";
 import ResizeObserver from "resize-observer-polyfill";
 
 interface Bounds {
-  left: number;
-  top: number;
-  width: number;
-  height: number;
+	left: number;
+	top: number;
+	width: number;
+	height: number;
 }
 const initialBounds: Bounds = { left: 0, top: 0, width: 0, height: 0 };
 function useBoundingClientRect(ref: React.RefObject<HTMLDivElement>): Bounds {
-  const [bounds, set] = useState<Bounds>(initialBounds);
-  const [ro] = useState(
-    () =>
-      new ResizeObserver(([entry]: ResizeObserverEntry[]) =>
-        set(entry.target.getBoundingClientRect())
-      )
-  );
-  useEffect(() => {
-    if (ref.current) ro.observe(ref.current);
-    return () => ro.disconnect();
-  }, []);
-  return bounds;
+	const [bounds, set] = useState<Bounds>(initialBounds);
+	const [ro] = useState(
+		() =>
+			new ResizeObserver(([entry]: ResizeObserverEntry[]) =>
+				set(entry.target.getBoundingClientRect())
+			)
+	);
+	useEffect(() => {
+		if (ref.current) ro.observe(ref.current);
+		return () => ro.disconnect();
+	}, [ref, ro]);
+	return bounds;
 }
 
 export const use3dEffect = (
-  ref: React.RefObject<HTMLDivElement>
+	ref: React.RefObject<HTMLDivElement>
 ): {
-  style: React.CSSProperties;
-  onMouseLeave: () => void;
-  onMouseEnter: (event: React.MouseEvent) => void;
+	onMouseLeave: () => void;
+	onMouseEnter: (event: React.MouseEvent) => void;
+	style: React.CSSProperties;
 } => {
-  const [props, set] = useSpring(() => ({
-    xys: [0, 0, 1],
-    config: { mass: 5, tension: 350, friction: 40 }
-  }));
-  const { top, left, width, height } = useBoundingClientRect(ref);
+	const trans = (x: number, y: number, s: number): String =>
+		`perspective(1000px) rotateX(${x}deg) rotateY(${-y}deg) scale(${s})`;
 
-  const calc = (x: number, y: number): number[] => [
-    -((top + height / 2 - y) / (height / 2)) * 10,
-    -((left + width / 2 - x) / (width / 2)) * 10,
-    1.1
-  ];
-  const trans = (x: number, y: number, s: number): string =>
-    `perspective(1000px) rotateX(${x}deg) rotateY(${-y}deg) scale(${s})`;
+	const [style, api] = useSpring(() => ({
+		xys: trans(0, 0, 1),
+		config: { mass: 5, tension: 350, friction: 40 },
+	}));
 
-  return {
-    style: {
-      // @ts-ignore
-      transform: props.xys.interpolate(trans)
-    },
-    onMouseLeave: () => set({ xys: [0, 0, 1] }),
-    // @ts-ignore
-    onMouseMove: ({ pageX: x, pageY: y }: React.MouseEvent) =>
-      set({ xys: calc(x, y) })
-  };
+	const { top, left, width, height } = useBoundingClientRect(ref);
+
+	const calc = (x: number, y: number): String => {
+    //TODO: instead of 'top' that counts from the current viewport the distance, might use something else that count from the document top y=0 
+    //TODO: you can also manually change 'top' with the current y=0 of the element but it's not really nice doing this way
+		const rY: number =
+			y > top + height / 2
+				? ((top + height / 2 - y) / (height / 2)) * 10
+				: -((top + height / 2 - y) / (height / 2)) * 10;
+
+		const array: number[] = [
+			rY,
+			((left + width / 2 - x) / (width / 2)) * 10,
+			1.1,
+		];
+		return trans(array[0], array[1], array[2]);
+	};
+
+	return {
+		onMouseLeave: () =>
+			api({
+				xys: trans(0, 0, 1),
+			}),
+		// @ts-ignore
+		onMouseMove: ({ pageX: x, pageY: y }: React.MouseEvent) => {
+			api({ xys: calc(x, y) });
+		},
+		style: {
+			// @ts-ignore
+			transform: style.xys,
+		},
+	};
 };


### PR DESCRIPTION
fixed the 'props.xys' undefined by refactoring a little the code,  now props is called style and have directly on it the trans function that accepts the values as props, without the need to have the 'interpolate(trans)' on the return statement, also changed the version of the react-spring from the 8.0.14 to the 8.0.27